### PR TITLE
Configurable sync interval

### DIFF
--- a/feature/templates/deployment.yaml
+++ b/feature/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
       containers:
       - args:
         - --leader-elect
+        - --sync-interval={{ .Values.syncIntervalMinutes }}
         command:
         - /manager
         env:
@@ -47,8 +48,6 @@ spec:
           value: cluster.local
         - name: DEBUG
           value: "{{ .Values.debug }}"
-        - name: SYNC_INTERVAL_MINUTES
-          value: "{{ .Values.syncIntervalMinutes }}"
         image: {{ .Values.image.repository }}:{{ .Chart.Version }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:

--- a/feature/templates/deployment.yaml
+++ b/feature/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
           value: cluster.local
         - name: DEBUG
           value: "{{ .Values.debug }}"
+        - name: SYNC_INTERVAL_MINUTES
+          value: "{{ .Values.syncIntervalMinutes }}"
         image: {{ .Values.image.repository }}:{{ .Chart.Version }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:

--- a/feature/templates/deployment.yaml
+++ b/feature/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --sync-interval={{ .Values.syncIntervalMinutes }}
+        - --sync-interval={{ .Values.syncInterval }}
         command:
         - /manager
         env:

--- a/feature/values.yaml
+++ b/feature/values.yaml
@@ -11,4 +11,4 @@ replicas: 1
 apiserverIP: "" # mapping value from Fasit
 debug: false
 monitoring: true
-syncIntervalMinutes: 15m
+syncInterval: 15m

--- a/feature/values.yaml
+++ b/feature/values.yaml
@@ -11,3 +11,4 @@ replicas: 1
 apiserverIP: "" # mapping value from Fasit
 debug: false
 monitoring: true
+syncIntervalMinutes: 15m

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"text/template"
 
+	b64 "encoding/base64"
+
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -56,7 +58,9 @@ func repairMapAny(v any) any {
 }
 
 func renderString(values any, tpl string, tplOptions ...RenderOption) (string, error) {
-	t := template.New("tpl").Delims("[[", "]]")
+	t := template.New("tpl").Delims("[[", "]]").Funcs(template.FuncMap{
+		"b64enc": b64enc,
+	})
 	for _, option := range tplOptions {
 		t = option(t)
 	}
@@ -70,4 +74,8 @@ func renderString(values any, tpl string, tplOptions ...RenderOption) (string, e
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func b64enc(s string) string {
+	return b64.StdEncoding.EncodeToString([]byte(s))
 }

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -75,6 +75,7 @@ func renderString(values any, tpl string, tplOptions ...RenderOption) (string, e
 	return buf.String(), nil
 }
 
-func b64enc(s string) string {
+func b64enc(in any) string {
+	s, _ := in.(string)
 	return base64.StdEncoding.EncodeToString([]byte(s))
 }

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -2,9 +2,8 @@ package template
 
 import (
 	"bytes"
+	"encoding/base64"
 	"text/template"
-
-	b64 "encoding/base64"
 
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -77,5 +76,5 @@ func renderString(values any, tpl string, tplOptions ...RenderOption) (string, e
 }
 
 func b64enc(s string) string {
-	return b64.StdEncoding.EncodeToString([]byte(s))
+	return base64.StdEncoding.EncodeToString([]byte(s))
 }

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strconv"
 	"time"
 
 	"nais/replicator/internal/logger"
@@ -60,6 +61,7 @@ func main() {
 	var probeAddr string
 	var enableWebhooks bool
 	var debug bool
+	var syncInterval string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -67,6 +69,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", true, "Enable webhooks")
 	flag.BoolVar(&debug, "debug", os.Getenv("DEBUG") == "true", "Enable debug logging")
+	flag.StringVar(&syncInterval, "sync-interval", os.Getenv("SYNC_INTERVAL_MINUTES"), "Syncronization interval for reconciliation in minutes")
 
 	opts := zap.Options{
 		Development: true,
@@ -86,6 +89,15 @@ func main() {
 	}
 
 	interval := 15 * time.Minute
+	if syncInterval != "" {
+		syncIntervalInt, err := strconv.Atoi(syncInterval)
+		if err != nil {
+			log.Errorf("unable to convert sync interval to number %v", err)
+			os.Exit(1)
+		}
+		interval = time.Duration(syncIntervalInt) * time.Minute
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", true, "Enable webhooks")
 	flag.BoolVar(&debug, "debug", os.Getenv("DEBUG") == "true", "Enable debug logging")
-	flag.StringVar(&syncInterval, "sync-interval", os.Getenv("SYNC_INTERVAL_MINUTES"), "Syncronization interval for reconciliation in minutes")
+	flag.StringVar(&syncInterval, "sync-interval", os.Getenv("SYNC_INTERVAL_MINUTES"), "Synchronization interval for reconciliation in minutes")
 
 	opts := zap.Options{
 		Development: true,


### PR DESCRIPTION
Proposed changes:
- sync interval configurable with either `sync-interval` flag or `SYNC_INTERVAL_MINUTES` env
- add templating function for optionally base64 encoding values