### PR TITLE
Hash content

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,5 +1,7 @@
 apiVersion: v2
 name: replicator
+sources:
+  - https://github.com/nais/replicator/tree/main/charts
 description: Replicator helm chart
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -4,4 +4,4 @@ sources:
   - https://github.com/nais/replicator/tree/main/charts
 description: Replicator helm chart
 type: application
-version: 1.0.1
+version: 1.1.0

--- a/controllers/replicationconfig_controller.go
+++ b/controllers/replicationconfig_controller.go
@@ -6,6 +6,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"nais/replicator/internal/content"
+	"os"
 	"time"
 
 	"nais/replicator/internal/replicator"
@@ -91,7 +92,9 @@ func (r *ReplicationConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 		for _, resource := range renderResources {
 			log.Debugf("reconciling resource %s%q", resource.GetKind(), resource.GetName())
-			spew.Dump(resource)
+			if os.Getenv("DEBUG") == "true" {
+				spew.Dump(resource)
+			}
 
 			resource.SetNamespace(ns.Name)
 			resource.SetOwnerReferences(ownerRef)
@@ -193,7 +196,7 @@ func (r *ReplicationConfigReconciler) updateResource(ctx context.Context, resour
 		log.Infof("updated resource %s%q to namespace %q", resource.GetKind(), resource.GetName(), resource.GetNamespace())
 		return nil
 	}
-	log.Infof("unchanged resource %s%q for namespace %q", resource.GetKind(), resource.GetName(), resource.GetNamespace())
+	log.Debugf("unchanged resource %s%q for namespace %q", resource.GetKind(), resource.GetName(), resource.GetNamespace())
 	return nil
 }
 

--- a/controllers/replicationconfig_controller.go
+++ b/controllers/replicationconfig_controller.go
@@ -170,16 +170,17 @@ func (r *ReplicationConfigReconciler) createUpdateResource(ctx context.Context, 
 }
 
 func (r *ReplicationConfigReconciler) updateResource(ctx context.Context, resource, existing *unstructured.Unstructured) error {
-	contentHash, err := content.GetContentHash(resource)
+	resourceContent, err := content.Get(resource)
 	if err != nil {
 		log.Warnf("unable to set resource content type: %v", err)
 	}
 
-	changed, err := contentHash.CompareTo(existing)
+	existingContent, err := content.Get(existing)
 	if err != nil {
-		return fmt.Errorf("comparing resources: %w", err)
+		log.Warnf("unable to set existing content type: %v", err)
 	}
-	if changed {
+
+	if !resourceContent.Equals(existingContent.Hash()) {
 		resource.SetResourceVersion(existing.GetResourceVersion())
 		err := r.Update(ctx, resource)
 		if err != nil {

--- a/controllers/replicationconfig_controller.go
+++ b/controllers/replicationconfig_controller.go
@@ -180,7 +180,7 @@ func (r *ReplicationConfigReconciler) updateResource(ctx context.Context, resour
 		log.Warnf("unable to set existing content type: %v", err)
 	}
 
-	if !resourceContent.Equals(existingContent.Hash()) {
+	if !resourceContent.Equals(existingContent) {
 		resource.SetResourceVersion(existing.GetResourceVersion())
 		err := r.Update(ctx, resource)
 		if err != nil {

--- a/controllers/replicationconfig_controller.go
+++ b/controllers/replicationconfig_controller.go
@@ -180,16 +180,17 @@ func (r *ReplicationConfigReconciler) updateResource(ctx context.Context, resour
 		log.Warnf("unable to set existing content type: %v", err)
 	}
 
-	if !resourceContent.Equals(existingContent) {
-		resource.SetResourceVersion(existing.GetResourceVersion())
-		err := r.Update(ctx, resource)
-		if err != nil {
-			return fmt.Errorf("updating resource: %w", err)
-		}
-		log.Infof("updated resource %s%q to namespace %q", resource.GetKind(), resource.GetName(), resource.GetNamespace())
+	if resourceContent.Equals(existingContent) {
+		log.Debugf("unchanged resource %s%q for namespace %q", resource.GetKind(), resource.GetName(), resource.GetNamespace())
 		return nil
 	}
-	log.Debugf("unchanged resource %s%q for namespace %q", resource.GetKind(), resource.GetName(), resource.GetNamespace())
+
+	resource.SetResourceVersion(existing.GetResourceVersion())
+	err = r.Update(ctx, resource)
+	if err != nil {
+		return fmt.Errorf("updating resource: %w", err)
+	}
+	log.Infof("updated resource %s%q to namespace %q", resource.GetKind(), resource.GetName(), resource.GetNamespace())
 	return nil
 }
 

--- a/controllers/replicationconfig_controller.go
+++ b/controllers/replicationconfig_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"nais/replicator/internal/content"
 	"os"
 	"time"
@@ -147,15 +148,12 @@ func (r *ReplicationConfigReconciler) listNamespaces(ctx context.Context, ls *me
 func (r *ReplicationConfigReconciler) createUpdateResource(ctx context.Context, resource *unstructured.Unstructured) error {
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(resource.GroupVersionKind())
-	toCreate := false
 	err := r.Get(ctx, client.ObjectKeyFromObject(resource), existing)
-	if client.IgnoreNotFound(err) == nil {
-		toCreate = true
-	} else if err != nil {
+	if client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
-	if toCreate {
+	if errors.IsNotFound(err) {
 		err := r.Create(ctx, resource)
 		if client.IgnoreAlreadyExists(err) != nil {
 			return err

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -1,0 +1,126 @@
+package content
+
+import (
+	"fmt"
+	"github.com/mitchellh/hashstructure/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	SpecContent       = "spec"
+	DataContent       = "data"
+	StringDataContent = "stringData"
+	UnknownContent    = "unknown"
+)
+
+type ResourceContent interface {
+	ContentHasChanged(existing *unstructured.Unstructured) (bool, error)
+}
+
+type Spec struct {
+	data        *unstructured.Unstructured
+	ContentType string
+}
+
+type Data struct {
+	data        *unstructured.Unstructured
+	ContentType string
+}
+
+type StringData struct {
+	data        *unstructured.Unstructured
+	ContentType string
+}
+
+type Unknown struct {
+	data        *unstructured.Unstructured
+	ContentType string
+}
+
+func GetHash(data *unstructured.Unstructured) (ResourceContent, error) {
+	var resourceContent ResourceContent
+	var err error
+
+	switch {
+	case data.UnstructuredContent()[SpecContent] != nil:
+		resourceContent = &Spec{
+			data:        data,
+			ContentType: SpecContent,
+		}
+	case data.UnstructuredContent()[DataContent] != nil:
+		resourceContent = &Data{
+			data:        data,
+			ContentType: DataContent,
+		}
+	case data.UnstructuredContent()[StringDataContent] != nil:
+		resourceContent = &StringData{
+			data:        data,
+			ContentType: StringDataContent,
+		}
+	default:
+		resourceContent = &Unknown{
+			data:        data,
+			ContentType: UnknownContent,
+		}
+		err = fmt.Errorf("resource content type not found: %v", data.UnstructuredContent())
+	}
+	return resourceContent, err
+}
+
+func (s *Spec) ContentHasChanged(existing *unstructured.Unstructured) (bool, error) {
+	if change, err := hasChanged(s.data, existing, s.ContentType); err != nil {
+		return false, err
+	} else if change {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (d *Data) ContentHasChanged(existing *unstructured.Unstructured) (bool, error) {
+	if change, err := hasChanged(d.data, existing, d.ContentType); err != nil {
+		return false, err
+	} else if change {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (s *StringData) ContentHasChanged(existing *unstructured.Unstructured) (bool, error) {
+	if change, err := hasChanged(s.data, existing, s.ContentType); err != nil {
+		return false, err
+	} else if change {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (u *Unknown) ContentHasChanged(existing *unstructured.Unstructured) (bool, error) {
+	if change, err := hasChanged(u.data, existing, u.ContentType); err != nil {
+		return false, err
+	} else if change {
+		return true, nil
+	}
+	return false, nil
+}
+
+func hasChanged(resource, existing *unstructured.Unstructured, contentType string) (bool, error) {
+	existingDataHash, err := hash(existing, contentType)
+	if err != nil {
+		return false, err
+	}
+
+	resourceDataHash, err := hash(resource, contentType)
+	if err != nil {
+		return false, err
+	}
+
+	return existingDataHash != resourceDataHash, nil
+}
+
+func hash(input *unstructured.Unstructured, contentType string) (string, error) {
+	hash, err := hashstructure.Hash(input.UnstructuredContent()[contentType], hashstructure.FormatV2, nil)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hash), nil
+}

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	b64 "encoding/base64"
 	"fmt"
 	"github.com/mitchellh/hashstructure/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -9,115 +8,27 @@ import (
 
 const (
 	SpecContent       = "spec"
+	UnknownContent    = "unknown"
 	DataContent       = "data"
 	StringDataContent = "stringData"
-	UnknownContent    = "unknown"
 )
 
 type ResourceContent interface {
-	CompareTo(existing *unstructured.Unstructured) (bool, error)
+	Equals(hash string) bool
+	Hash() string
 }
 
-type Spec struct {
-	contentHash string
-	contentType string
-	data        *unstructured.Unstructured
-}
-
-type Data struct {
-	contentHash string
-	contentType string
-	data        *unstructured.Unstructured
-}
-
-type StringData struct {
-	contentHash string
-	contentType string
-	data        *unstructured.Unstructured
-}
-
-func GetContentHash(data *unstructured.Unstructured) (ResourceContent, error) {
-	var resourceContent ResourceContent
-	var content map[string]interface{}
-	var err error
-	var hash string
-
+func Get(data *unstructured.Unstructured) (ResourceContent, error) {
 	switch {
 	case data.UnstructuredContent()[SpecContent] != nil:
-		content, err = getContent(data, SpecContent)
-		hash, err = toHash(content)
-		if err != nil {
-			return nil, err
-		}
-		resourceContent = &Spec{
-			contentHash: hash,
-			contentType: SpecContent,
-			data:        data,
-		}
+		return NewSpec(data)
 	case data.UnstructuredContent()[DataContent] != nil:
-		content, err = getContent(data, DataContent)
-		hash, err = toHash(content)
-		if err != nil {
-			return nil, err
-		}
-		resourceContent = &Data{
-			contentHash: hash,
-			contentType: DataContent,
-			data:        data,
-		}
+		return NewData(data)
 	case data.UnstructuredContent()[StringDataContent] != nil:
-		content, err = getContent(data, StringDataContent)
-		encodedValues := copyToEncodedValues(content)
-		hash, err = toHash(encodedValues)
-		resourceContent = &StringData{
-			contentHash: hash,
-			contentType: StringDataContent,
-			data:        data,
-		}
+		return NewStringData(data)
 	default:
-		_, err = getContent(data, UnknownContent)
+		return NewUnknown(data)
 	}
-	return resourceContent, err
-}
-
-func (s *Spec) CompareTo(existing *unstructured.Unstructured) (bool, error) {
-	existingData, err := getContent(existing, s.contentType)
-	if err != nil {
-		return false, err
-	}
-	existingHash, err := toHash(existingData)
-	if err != nil {
-		return false, err
-	}
-	return hasChanged(s.contentHash, existingHash), nil
-}
-
-func (d *Data) CompareTo(existing *unstructured.Unstructured) (bool, error) {
-	existingData, err := getContent(existing, d.contentType)
-	if err != nil {
-		return false, err
-	}
-	existingHash, err := toHash(existingData)
-	if err != nil {
-		return false, err
-	}
-	return hasChanged(d.contentHash, existingHash), nil
-}
-
-func (s *StringData) CompareTo(existing *unstructured.Unstructured) (bool, error) {
-	existingData, err := getContent(existing, DataContent)
-	if err != nil {
-		return false, err
-	}
-	existingHash, err := toHash(existingData)
-	if err != nil {
-		return false, err
-	}
-	return hasChanged(s.contentHash, existingHash), nil
-}
-
-func hasChanged(resourceHash, existingHash string) bool {
-	return resourceHash != existingHash
 }
 
 func toHash(input map[string]interface{}) (string, error) {
@@ -128,19 +39,9 @@ func toHash(input map[string]interface{}) (string, error) {
 	return fmt.Sprintf("%x", hash), nil
 }
 
-func copyToEncodedValues(resources map[string]interface{}) map[string]interface{} {
-	outputs := make(map[string]interface{}, len(resources))
-
-	for k, v := range resources {
-		outputs[k] = b64.StdEncoding.EncodeToString([]byte(v.(string)))
-	}
-	return outputs
-}
-
 func getContent(data *unstructured.Unstructured, contentType string) (map[string]interface{}, error) {
 	if data.UnstructuredContent()[contentType] == nil {
 		return nil, fmt.Errorf("content type %q not found with data %v", contentType, data.UnstructuredContent())
 	}
-
 	return data.UnstructuredContent()[contentType].(map[string]interface{}), nil
 }

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -14,7 +14,7 @@ const (
 )
 
 type ResourceContent interface {
-	Equals(hash string) bool
+	Equals(content ResourceContent) bool
 	Hash() string
 }
 

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -1,91 +1,130 @@
 package content
 
 import (
+	"encoding/base64"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"testing"
 )
 
-func TestHasChanged(t *testing.T) {
+func TestContentHasChanged(t *testing.T) {
 	for _, tt := range []struct {
-		name     string
-		existing *unstructured.Unstructured
-		input    *unstructured.Unstructured
-		changed  bool
-		error    bool
+		name           string
+		existingData   *unstructured.Unstructured
+		rcInput        *unstructured.Unstructured
+		expectedChange bool
+		expectedError  bool
 	}{
 		{
-			name:    "resource 'unknown' is a unknown resource, it should return fail",
-			changed: false,
-			error:   true,
-			existing: unstructuredData("unknown", map[string]interface{}{
+			name:          "'unknown' should return fail",
+			expectedError: true,
+			existingData: unstructuredData(UnknownContent, map[string]interface{}{
 				"key": "value",
 			}),
-			input: unstructuredData("unknown", map[string]interface{}{
-				"key": "value",
-			}),
-		},
-		{
-			name:    "resource 'stringData' has not changed, it should return false",
-			changed: false,
-			existing: unstructuredData("stringData", map[string]interface{}{
-				"key": "value",
-			}),
-			input: unstructuredData("stringData", map[string]interface{}{
+			rcInput: unstructuredData("some-data", map[string]interface{}{
 				"key": "value",
 			}),
 		},
 		{
-			name:    "resource 'data' has not changed, it should return false",
-			changed: false,
-			existing: unstructuredData("data", map[string]interface{}{
+			name: "'stringData' has not changed, it should return false",
+			existingData: unstructuredData(DataContent, map[string]interface{}{
+				"key": base64.StdEncoding.EncodeToString([]byte("my-value")),
+			}),
+			rcInput: unstructuredData(StringDataContent, map[string]interface{}{
+				"key": "my-value",
+			}),
+		},
+
+		{
+			name:           "existingData 'stringData' changed, it should return true",
+			expectedChange: true,
+			existingData: unstructuredData(DataContent, map[string]interface{}{
+				"key":       base64.StdEncoding.EncodeToString([]byte("my-value")),
+				"other-key": base64.StdEncoding.EncodeToString([]byte("my-other-value")),
+			}),
+			rcInput: unstructuredData(StringDataContent, map[string]interface{}{
+				"key": "my-value",
+			}),
+		},
+		{
+			name:           "rcInput 'stringData' has changed, it should return true",
+			expectedChange: true,
+			existingData: unstructuredData(DataContent, map[string]interface{}{
+				"key": base64.StdEncoding.EncodeToString([]byte("my-value")),
+			}),
+			rcInput: unstructuredData(StringDataContent, map[string]interface{}{
+				"key": "otherValue",
+			}),
+		},
+		{
+			name: "'data' has not changed, it should return false",
+			existingData: unstructuredData(DataContent, map[string]interface{}{
 				"key": "value",
 			}),
-			input: unstructuredData("data", map[string]interface{}{
+			rcInput: unstructuredData(DataContent, map[string]interface{}{
 				"key": "value",
 			}),
 		},
 		{
-			name:    "resource 'spec' has not changed, it should return false",
-			changed: false,
-			existing: unstructuredData("spec", map[string]interface{}{
+			name:           "existingData 'data' changed, it should return true",
+			expectedChange: true,
+			existingData: unstructuredData(DataContent, map[string]interface{}{
+				"other-key": "value",
+			}),
+			rcInput: unstructuredData(DataContent, map[string]interface{}{
+				"key": "value",
+			}),
+		},
+		{
+			name:           "rcInput 'data' changed, it should return true",
+			expectedChange: true,
+			existingData: unstructuredData(DataContent, map[string]interface{}{
+				"other-key": "value",
+			}),
+			rcInput: unstructuredData(DataContent, map[string]interface{}{
+				"key": "value",
+			}),
+		},
+		{
+			name: "'spec' has not changed, it should return false",
+			existingData: unstructuredData(SpecContent, map[string]interface{}{
 				"replicas": "1",
 			}),
-			input: unstructuredData("spec", map[string]interface{}{
+			rcInput: unstructuredData(SpecContent, map[string]interface{}{
 				"replicas": "1",
 			}),
 		},
 		{
-			name:    "existing resource 'spec' has changed, it should return true",
-			changed: true,
-			existing: unstructuredData("spec", map[string]interface{}{
+			name:           "existingData 'spec' has changed, it should return true",
+			expectedChange: true,
+			existingData: unstructuredData(SpecContent, map[string]interface{}{
 				"replicas": "2",
 			}),
-			input: unstructuredData("spec", map[string]interface{}{
+			rcInput: unstructuredData(SpecContent, map[string]interface{}{
 				"replicas": "1",
 			}),
 		},
 		{
-			name:    "input resource 'spec' has changed, it should return true",
-			changed: true,
-			existing: unstructuredData("spec", map[string]interface{}{
+			name:           "rcInput 'spec' has changed, it should return true",
+			expectedChange: true,
+			existingData: unstructuredData(SpecContent, map[string]interface{}{
 				"replicas": "1",
 			}),
-			input: unstructuredData("spec", map[string]interface{}{
+			rcInput: unstructuredData(SpecContent, map[string]interface{}{
 				"replicas": "2",
 			}),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			getHash, err := GetHash(tt.input)
-			if tt.error {
+			getHash, err := GetHash(tt.rcInput)
+			if tt.expectedError {
 				assert.Error(t, err)
 				return
 			}
 
-			changed, err := getHash.ContentHasChanged(tt.existing)
+			changed, err := getHash.ContentHasChanged(tt.existingData)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.changed, changed)
+			assert.Equal(t, tt.expectedChange, changed)
 		})
 	}
 }

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -126,8 +126,8 @@ func TestContentHasChanged(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			change := rcContent.Equals(existingContent.Hash())
-			assert.Equal(t, tt.expectedChange, !change)
+
+			assert.Equal(t, tt.expectedChange, !rcContent.Equals(existingContent))
 		})
 	}
 }

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -1,0 +1,102 @@
+package content
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"testing"
+)
+
+func TestHasChanged(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		existing *unstructured.Unstructured
+		input    *unstructured.Unstructured
+		changed  bool
+		error    bool
+	}{
+		{
+			name:    "resource 'unknown' is a unknown resource, it should return fail",
+			changed: false,
+			error:   true,
+			existing: unstructuredData("unknown", map[string]interface{}{
+				"key": "value",
+			}),
+			input: unstructuredData("unknown", map[string]interface{}{
+				"key": "value",
+			}),
+		},
+		{
+			name:    "resource 'stringData' has not changed, it should return false",
+			changed: false,
+			existing: unstructuredData("stringData", map[string]interface{}{
+				"key": "value",
+			}),
+			input: unstructuredData("stringData", map[string]interface{}{
+				"key": "value",
+			}),
+		},
+		{
+			name:    "resource 'data' has not changed, it should return false",
+			changed: false,
+			existing: unstructuredData("data", map[string]interface{}{
+				"key": "value",
+			}),
+			input: unstructuredData("data", map[string]interface{}{
+				"key": "value",
+			}),
+		},
+		{
+			name:    "resource 'spec' has not changed, it should return false",
+			changed: false,
+			existing: unstructuredData("spec", map[string]interface{}{
+				"replicas": "1",
+			}),
+			input: unstructuredData("spec", map[string]interface{}{
+				"replicas": "1",
+			}),
+		},
+		{
+			name:    "existing resource 'spec' has changed, it should return true",
+			changed: true,
+			existing: unstructuredData("spec", map[string]interface{}{
+				"replicas": "2",
+			}),
+			input: unstructuredData("spec", map[string]interface{}{
+				"replicas": "1",
+			}),
+		},
+		{
+			name:    "input resource 'spec' has changed, it should return true",
+			changed: true,
+			existing: unstructuredData("spec", map[string]interface{}{
+				"replicas": "1",
+			}),
+			input: unstructuredData("spec", map[string]interface{}{
+				"replicas": "2",
+			}),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			getHash, err := GetHash(tt.input)
+			if tt.error {
+				assert.Error(t, err)
+				return
+			}
+
+			changed, err := getHash.ContentHasChanged(tt.existing)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.changed, changed)
+		})
+	}
+}
+
+func unstructuredData(inputKey string, inputValue map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "test",
+			},
+			inputKey: inputValue,
+		},
+	}
+}

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -21,7 +21,7 @@ func TestContentHasChanged(t *testing.T) {
 			existingData: unstructuredData(UnknownContent, map[string]interface{}{
 				"key": "value",
 			}),
-			rcInput: unstructuredData("some-data", map[string]interface{}{
+			rcInput: unstructuredData("some-new-content", map[string]interface{}{
 				"key": "value",
 			}),
 		},
@@ -116,13 +116,13 @@ func TestContentHasChanged(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			getHash, err := GetHash(tt.rcInput)
+			getHash, err := GetContentHash(tt.rcInput)
 			if tt.expectedError {
 				assert.Error(t, err)
 				return
 			}
 
-			changed, err := getHash.ContentHasChanged(tt.existingData)
+			changed, err := getHash.CompareTo(tt.existingData)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedChange, changed)
 		})

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -116,15 +116,18 @@ func TestContentHasChanged(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			getHash, err := GetContentHash(tt.rcInput)
+			rcContent, err := Get(tt.rcInput)
 			if tt.expectedError {
 				assert.Error(t, err)
 				return
 			}
-
-			changed, err := getHash.CompareTo(tt.existingData)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedChange, changed)
+			existingContent, err := Get(tt.existingData)
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+			change := rcContent.Equals(existingContent.Hash())
+			assert.Equal(t, tt.expectedChange, !change)
 		})
 	}
 }

--- a/internal/content/data.go
+++ b/internal/content/data.go
@@ -1,0 +1,31 @@
+package content
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+type Data struct {
+	contentHash string
+	contentData map[string]interface{}
+}
+
+func NewData(data *unstructured.Unstructured) (*Data, error) {
+	content, err := getContent(data, DataContent)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := toHash(content)
+	if err != nil {
+		return nil, err
+	}
+	return &Data{
+		contentHash: hash,
+		contentData: content,
+	}, nil
+}
+
+func (d *Data) Equals(existingHash string) bool {
+	return d.contentHash == existingHash
+}
+
+func (d *Data) Hash() string {
+	return d.contentHash
+}

--- a/internal/content/data.go
+++ b/internal/content/data.go
@@ -22,8 +22,8 @@ func NewData(data *unstructured.Unstructured) (*Data, error) {
 	}, nil
 }
 
-func (d *Data) Equals(existingHash string) bool {
-	return d.contentHash == existingHash
+func (d *Data) Equals(content ResourceContent) bool {
+	return d.contentHash == content.Hash()
 }
 
 func (d *Data) Hash() string {

--- a/internal/content/spec.go
+++ b/internal/content/spec.go
@@ -1,0 +1,31 @@
+package content
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+type Spec struct {
+	contentHash string
+	contentData map[string]interface{}
+}
+
+func NewSpec(data *unstructured.Unstructured) (*Spec, error) {
+	content, err := getContent(data, SpecContent)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := toHash(content)
+	if err != nil {
+		return nil, err
+	}
+	return &Spec{
+		contentHash: hash,
+		contentData: content,
+	}, nil
+}
+
+func (s *Spec) Equals(existingHash string) bool {
+	return s.contentHash == existingHash
+}
+
+func (s *Spec) Hash() string {
+	return s.contentHash
+}

--- a/internal/content/spec.go
+++ b/internal/content/spec.go
@@ -22,8 +22,8 @@ func NewSpec(data *unstructured.Unstructured) (*Spec, error) {
 	}, nil
 }
 
-func (s *Spec) Equals(existingHash string) bool {
-	return s.contentHash == existingHash
+func (s *Spec) Equals(content ResourceContent) bool {
+	return s.contentHash == content.Hash()
 }
 
 func (s *Spec) Hash() string {

--- a/internal/content/stringdata.go
+++ b/internal/content/stringdata.go
@@ -1,0 +1,43 @@
+package content
+
+import (
+	b64 "encoding/base64"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type StringData struct {
+	contentHash string
+	contentData map[string]interface{}
+}
+
+func NewStringData(data *unstructured.Unstructured) (*StringData, error) {
+	content, err := getContent(data, StringDataContent)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := toHash(copyToEncodedValues(content))
+	if err != nil {
+		return nil, err
+	}
+	return &StringData{
+		contentHash: hash,
+		contentData: content,
+	}, nil
+}
+
+func (s *StringData) Equals(existingHash string) bool {
+	return s.contentHash == existingHash
+}
+
+func (s *StringData) Hash() string {
+	return s.contentHash
+}
+
+func copyToEncodedValues(data map[string]interface{}) map[string]interface{} {
+	outputs := make(map[string]interface{}, len(data))
+
+	for k, v := range data {
+		outputs[k] = b64.StdEncoding.EncodeToString([]byte(v.(string)))
+	}
+	return outputs
+}

--- a/internal/content/stringdata.go
+++ b/internal/content/stringdata.go
@@ -25,8 +25,8 @@ func NewStringData(data *unstructured.Unstructured) (*StringData, error) {
 	}, nil
 }
 
-func (s *StringData) Equals(existingHash string) bool {
-	return s.contentHash == existingHash
+func (s *StringData) Equals(content ResourceContent) bool {
+	return s.contentHash == content.Hash()
 }
 
 func (s *StringData) Hash() string {

--- a/internal/content/unknown.go
+++ b/internal/content/unknown.go
@@ -1,0 +1,31 @@
+package content
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+type Unknown struct {
+	contentHash string
+	contentData map[string]interface{}
+}
+
+func NewUnknown(data *unstructured.Unstructured) (*Unknown, error) {
+	content, err := getContent(data, UnknownContent)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := toHash(content)
+	if err != nil {
+		return nil, err
+	}
+	return &Unknown{
+		contentHash: hash,
+		contentData: content,
+	}, nil
+}
+
+func (u *Unknown) Equals(existingHash string) bool {
+	return u.contentHash == existingHash
+}
+
+func (u *Unknown) Hash() string {
+	return u.contentHash
+}

--- a/internal/content/unknown.go
+++ b/internal/content/unknown.go
@@ -22,8 +22,8 @@ func NewUnknown(data *unstructured.Unstructured) (*Unknown, error) {
 	}, nil
 }
 
-func (u *Unknown) Equals(existingHash string) bool {
-	return u.contentHash == existingHash
+func (u *Unknown) Equals(content ResourceContent) bool {
+	return u.contentHash == content.Hash()
 }
 
 func (u *Unknown) Hash() string {


### PR DESCRIPTION
**Content hash**

Unnecessary update requests to the apiserver

One of the objectives for Replicator is to keep resources it owns up to date and to keep the "truth" reflecting the rc config.

Compare hash for the existing resource _content_ with the rc resource config _content_ to reduces update request to the apiserver.

This will help the FQDN-operator from failing, when the operator is trying to update is own resources (owned by replicator).